### PR TITLE
Updated mean_income_data in ogidn_default_parameters.json

### DIFF
--- a/ogidn/ogidn_default_parameters.json
+++ b/ogidn/ogidn_default_parameters.json
@@ -101444,7 +101444,7 @@
             ]
         ]
     ],
-    "mean_income_data": 58644.924039576625,
+    "mean_income_data": 77205806,
     "frac_tax_payroll": [
         0.46971242,
         0.46445368,


### PR DESCRIPTION
This PR updates the `mean_income_data` parameter in `ogidn_default_parameters.json` to IDR 77,205,806 which is based on per capita GDP in 2022 of $4,788 and a current exchange rate of 0.000062 IDR to 1 USD.

cc: @jdebacker 