### PR TITLE
Updates to environment and example script imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.0.7] - 2025-04-25 12:30:00
+
+### Added
+
+- Updates `environment.yml` to pin to `marshmallow` version < 4.0.0
+- Removes unused imports in example scripts
+
 ## [0.0.6] - 2025-03-17 12:30:00
 
 ### Added
@@ -41,7 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - This version is a pre-release alpha. The example run script OG-IDN/examples/run_og_idn.py runs, but the model is not currently calibrated to represent the Indonesian economy and population.
 
-
+[0.0.7]: https://github.com/EAPD-DRB/OG-IDN/compare/v0.0.6...v0.0.7
+[0.0.6]: https://github.com/EAPD-DRB/OG-IDN/compare/v0.0.5...v0.0.6
 [0.0.5]: https://github.com/EAPD-DRB/OG-IDN/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/EAPD-DRB/OG-IDN/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/EAPD-DRB/OG-IDN/compare/v0.0.0...v0.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.0.7] - 2025-04-25 12:30:00
+## [0.0.7] - 2025-04-28 12:00:00
 
 ### Added
 

--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
 - dask>=2.30.0
 - dask-core>=2.30.0
 - distributed>=2.30.1
+- marshmallow<4.0.0
 - paramtools>=0.15.0
 - sphinx>=3.5.4
 - sphinx-book-theme>=0.1.3

--- a/examples/run_og_idn.py
+++ b/examples/run_og_idn.py
@@ -7,12 +7,11 @@ import time
 import copy
 from importlib.resources import files
 import matplotlib.pyplot as plt
-import ogcore
 from ogcore.parameters import Specifications
 from ogcore import output_tables as ot
 from ogcore import output_plots as op
 from ogcore.execute import runner
-from ogcore.utils import safe_read_pickle, param_dump_json
+from ogcore.utils import safe_read_pickle
 from ogidn.calibrate import Calibration
 from ogidn.utils import is_connected
 

--- a/examples/run_og_idn_multisector.py
+++ b/examples/run_og_idn_multisector.py
@@ -7,14 +7,11 @@ import time
 import copy
 from importlib.resources import files
 import matplotlib.pyplot as plt
-import ogcore
 from ogcore.parameters import Specifications
 from ogcore import output_tables as ot
 from ogcore import output_plots as op
 from ogcore.execute import runner
-from ogcore.utils import safe_read_pickle, param_dump_json
-from ogidn.calibrate import Calibration
-from ogidn.utils import is_connected
+from ogcore.utils import safe_read_pickle
 
 # Use a custom matplotlib style file for plots
 plt.style.use("ogcore.OGcorePlots")

--- a/ogidn/__init__.py
+++ b/ogidn/__init__.py
@@ -8,4 +8,4 @@ from ogidn.input_output import *
 from ogidn.macro_params import *
 from ogidn.utils import *
 
-__version__ = "0.0.6"
+__version__ = "0.0.7"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setuptools.setup(
     name="ogidn",
-    version="0.0.6",
+    version="0.0.7",
     author="Marcelo LaFleur, Richard W. Evans, and Jason DeBacker",
     license="CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     description="Indonesia (IDN) Calibration for OG-Core",
@@ -35,6 +35,7 @@ setuptools.setup(
         "matplotlib",
         "dask>=2.30.0",
         "distributed>=2.30.1",
+        "marshmallow<4.0.0",
         "paramtools>=0.15.0",
         "requests",
         "pandas-datareader",


### PR DESCRIPTION
This PR does two things:
1. It adds a pin for `marshmallow<4.0.0` to `enviornment.yml`.  This is a temporary fix to a breaking change in `paramtools` caused by the update to `marshmallow 4.0.0` (see ParamTools [Issue #144](https://github.com/PSLmodels/ParamTools/issues/144))
2. Unused imports are removed from the example scripts