### PR TITLE
Isolate network calls in calibration; drop pandas-datareader and statsmodels

### DIFF
--- a/.github/workflows/docs_check.yml
+++ b/.github/workflows/docs_check.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Build # Build Jupyter Book
         shell: bash -l {0}
         run: |
-          pip install jupyter-book>=0.11.3
-          pip install sphinxcontrib-bibtex>=2.0.0
+          pip install "jupyter-book<2.0.0"
+          pip install "sphinxcontrib-bibtex>=2.0.0"
           pip install -e .
           python -m ipykernel install --user --name=ogidn-dev
           jb build ./docs/book

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+## Workflow
+
+- Read-only inspection does not require prior approval. This includes actions like checking status, listing branches or worktrees, inspecting tracking refs, reviewing merged status, reading files, and preparing a proposed cleanup list.
+- Present a plan and wait for explicit approval before making changes to repo state. This includes file edits, branch deletion, pruning refs or worktrees, rebases, merges, commits, pushes, and similar mutating actions.
+
+## Project: OG-IDN
+
+OG-IDN is an Indonesia country calibration of the OG-Core overlapping-generations model of demographics and fiscal policy.
+
+## Environment
+
+- Conda environment: `ogidn-dev`
+
+## Python formatting
+
+- Run `black` on all touched `.py` files before staging and pushing.
+- Do not run `black` on non-Python files (e.g. README.md will fail to parse).
+- Re-run tests after formatting to confirm nothing broke.
+- Format command: `conda run -n ogidn-dev python -m black <files>`
+
+## Testing
+
+- Full suite: `conda run -n ogidn-dev python -m pytest tests/ -q`
+- Targeted: `conda run -n ogidn-dev python -m pytest tests/test_calibrate.py tests/test_input_output.py tests/test_macro_params.py -q`
+
+## Repo conventions
+
+- The packaged JSON default parameters are the standard baseline input for offline/default runs.
+- Calibration-related changes can affect macro parameters, demographics, earnings distribution, and industry I/O behavior.
+- Changes in calibration or data-source behavior should be validated with targeted tests and, where feasible, the relevant example flows.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Once the package is installed, one can adjust parameters in the OG-Core `Specifi
 from ogcore.parameters import Specifications
 from ogidn.calibrate import Calibration
 p = Specifications()
-c = Calibration(p)
+c = Calibration(p, update_from_api=True)
 updated_params = c.get_dict()
 p.update_specifications({'initial_debt_ratio': updated_params['initial_debt_ratio']})
 ```

--- a/docs/book/content/UNtutorial/materials/PrevReformsNotebooks/run_scripts/run_og_idn_education.py
+++ b/docs/book/content/UNtutorial/materials/PrevReformsNotebooks/run_scripts/run_og_idn_education.py
@@ -17,7 +17,6 @@ import ogcore
 from ogcore.execute import runner
 from ogcore.utils import safe_read_pickle
 
-
 # Use a custom matplotlib style file for plots
 plt.style.use("ogcore.OGcorePlots")
 

--- a/docs/book/content/UNtutorial/solutions/3perOG/SS.py
+++ b/docs/book/content/UNtutorial/solutions/3perOG/SS.py
@@ -28,7 +28,6 @@ import matplotlib.pyplot as plt
 from matplotlib.ticker import MultipleLocator
 import os
 
-
 # Define functions
 
 

--- a/docs/book/content/calibration/macro.md
+++ b/docs/book/content/calibration/macro.md
@@ -27,34 +27,49 @@ The path of government debt is endogenous.  But the initial value is exogenous. 
 
 #### Interest rates on government debt
 
-We assume that there is a wedge between the real rate of return on private capital and the real interest rate on government debt.  We model this wedge a scale and level shift.  Specifically, we assume that the real interest rate on government debt, $r_{gov,t}$, is related to the real rate of return on private capital, $r_{t}$, by the following equation:
+We assume a wedge between the real rate of return on private capital and the real interest rate on government debt, modeled as a scale and level shift.  The real interest rate on government debt, $r_{gov,t}$, relates to the real rate of return on private capital, $r_t$, by
 
 ```{math}
 :label: eqn:r_gov
-    r_{gov,t} = (1-\tau_{d,t})r_t + \mu_d
+    r_{gov,t} = (1-\tau_{d,t}) r_t + \mu_d
 ```
 
-where $\tau_d$ is the scale parameter and $\mu_d$ is the level shift parameter.  We set the values of these two parameters to 0.24485 and -0.03377, respectively.  These are found by using the estimated relationship between corporate and sovereign yields in {cite}`LMW2023` (Table 8, Column 2) and simulating a series of corporate yields given a series of sovereign yields between 2% and 12%.  We then estimate the scale and level shift parameters that best fit these simulated data using ordinary least squares.
+where $(1-\tau_d)$ is the pass-through coefficient and $\mu_d$ is the level shift.  For Indonesia we use $1-\tau_d = 0.24485$ (so $\tau_d = 0.75515$) and $\mu_d = 0.03377$.
 
-Because the inputs to this OLS are deterministic (a fixed quadratic over a fixed sovereign yield grid) and contain no Indonesia-specific data, the resulting values of `r_gov_scale` and `r_gov_shift` do not change across calibration runs.  Rather than refitting the same regression every time `get_macro_params(update_from_api=True)` is called, the packaged values in `ogidn/ogidn_default_parameters.json` (and `ogidn/ogidn_multisector_default_parameters.json`) are the authoritative source.  The snippet below reproduces them for reviewers and documents the methodology:
+These values come from {cite}`LMW2023`, who estimate the long-run pass-through of sovereign yields to corporate yields across 46 emerging economies using corporate yields from IHS Markit and sovereign yields from Bloomberg (predominantly U.S.-dollar secondary-market yields).  They are therefore a cross-country emerging-market relationship rather than Indonesia-specific bond data.  Their preferred specification (Table 8, Column 2) fits a quadratic of the corporate yield on the sovereign yield of the same country:
+
+```{math}
+:label: eqn:lmw_quadratic
+    y_{corp} = 8.199 - 2.975\, y_{sov} + 0.478\, y_{sov}^2
+```
+
+with both yields in percentage points.  The quadratic captures the empirical fact that pass-through rises with the level of sovereign risk, consistent with the credit-risk and liquidity-premium channels the paper identifies.  The paper is freely available as an IMF Working Paper, [Li, Magud, and Werner (2021)](https://www.imf.org/en/Publications/WP/Issues/2021/06/04/The-Long-Run-Impact-of-Sovereign-Yields-on-Corporate-Yields-in-Emerging-Markets-50224), and was later published in the *Journal of International Money and Finance* {cite}`LMW2023`.
+
+OG-Core models the wedge in the opposite direction — it takes $r_t$ as an input and produces $r_{gov,t}$ — so we invert the LMW relationship.  We evaluate their quadratic on a grid of sovereign yields from 2% to 12% (approximately the emerging-market range in the LMW sample), compute the implied corporate yields, and then regress sovereign yields linearly on those corporate yields.  Calling the resulting slope $b$ and intercept $a$ (both in percentage points), we identify $1-\tau_d = b$ and $\mu_d = a/100$.
+
+OG-Core's operational formula is $r_{gov,t} = \max\!\big(\texttt{r\_gov\_scale}\cdot r_t - \texttt{r\_gov\_shift},\; 0\big)$, so the JSON stores `r_gov_scale = 1-τ_d = 0.24485` and `r_gov_shift = -μ_d = -0.03377`.  The negative sign on `r_gov_shift` reflects the subtraction in the OG-Core rule, not a negative level shift in the theoretical equation.
+
+Because the inputs to this inversion are deterministic and contain no Indonesia-specific data, the resulting values do not change across calibration runs.  The packaged values in `ogidn/ogidn_default_parameters.json` and `ogidn/ogidn_multisector_default_parameters.json` are the authoritative source.  The snippet below reproduces them for transparency:
 
 ```python
 import numpy as np
 import statsmodels.api as sm
 
+# LMW (2023) Table 8, Column 2: corp = 8.199 - 2.975 sov + 0.478 sov^2  (pct pts)
 sov_y = np.arange(20, 120) / 10
 corp_yhat = 8.199 - (2.975 * sov_y) + (0.478 * sov_y**2)
-corp_yhat = sm.add_constant(corp_yhat)
-res = sm.OLS(sov_y, corp_yhat).fit()
 
-r_gov_shift = -res.params[0] / 100
-r_gov_scale = res.params[1]
+# Invert: regress sov on corp → linear pass-through
+X = sm.add_constant(corp_yhat)
+res = sm.OLS(sov_y, X).fit()
 
-print(round(r_gov_shift, 5))  # -0.03377
-print(round(r_gov_scale, 5))  # 0.24485
+r_gov_shift = -res.params[0] / 100  # -0.03377  (= -μ_d in the theoretical equation)
+r_gov_scale = res.params[1]         #  0.24485  (= 1-τ_d in the theoretical equation)
 ```
 
-If {cite}`LMW2023` is ever superseded by a follow-up study with revised coefficients, re-run the snippet above and update the JSON values (see [OG-IDN](https://github.com/EAPD-DRB/OG-IDN)).
+If the LMW estimates are superseded, re-run the inversion above with the new coefficients and update the JSON values.
+
+For background on how this calibration was first derived, the slope/intercept mapping worked out, and the OG-Core specification refined, see the OG-ZAF discussion in issue [#22](https://github.com/EAPD-DRB/OG-ZAF/issues/22) and PRs [#24](https://github.com/EAPD-DRB/OG-ZAF/pull/24) (initial implementation) and [#30](https://github.com/EAPD-DRB/OG-ZAF/pull/30) (conversion of `r_gov` parameters to lists), together with OG-Core issue [#841](https://github.com/PSLmodels/OG-Core/issues/841) and PR [#844](https://github.com/PSLmodels/OG-Core/pull/844).
 
 ### Aggregate transfers
 

--- a/docs/book/content/calibration/macro.md
+++ b/docs/book/content/calibration/macro.md
@@ -34,7 +34,27 @@ We assume that there is a wedge between the real rate of return on private capit
     r_{gov,t} = (1-\tau_{d,t})r_t + \mu_d
 ```
 
-where $\tau_d$ is the scale parameter and $\mu_d$ is the level shift parameter.  We set the values of these two parameters to 0.245 and -0.034, respectively.  These are found by using the estimated relationship between corporate and sovereign yields in {cite}`LMW2023` (Table 8, Column 2) and simulating a series of corporate yields given a series of sovereign yields between 2% and 12%.  We then estimate the scale and level shift parameters that best fit these simulated data using ordinary least squares.
+where $\tau_d$ is the scale parameter and $\mu_d$ is the level shift parameter.  We set the values of these two parameters to 0.24485 and -0.03377, respectively.  These are found by using the estimated relationship between corporate and sovereign yields in {cite}`LMW2023` (Table 8, Column 2) and simulating a series of corporate yields given a series of sovereign yields between 2% and 12%.  We then estimate the scale and level shift parameters that best fit these simulated data using ordinary least squares.
+
+Because the inputs to this OLS are deterministic (a fixed quadratic over a fixed sovereign yield grid) and contain no Indonesia-specific data, the resulting values of `r_gov_scale` and `r_gov_shift` do not change across calibration runs.  Rather than refitting the same regression every time `get_macro_params(update_from_api=True)` is called, the packaged values in `ogidn/ogidn_default_parameters.json` (and `ogidn/ogidn_multisector_default_parameters.json`) are the authoritative source.  The snippet below reproduces them for reviewers and documents the methodology:
+
+```python
+import numpy as np
+import statsmodels.api as sm
+
+sov_y = np.arange(20, 120) / 10
+corp_yhat = 8.199 - (2.975 * sov_y) + (0.478 * sov_y**2)
+corp_yhat = sm.add_constant(corp_yhat)
+res = sm.OLS(sov_y, corp_yhat).fit()
+
+r_gov_shift = -res.params[0] / 100
+r_gov_scale = res.params[1]
+
+print(round(r_gov_shift, 5))  # -0.03377
+print(round(r_gov_scale, 5))  # 0.24485
+```
+
+If {cite}`LMW2023` is ever superseded by a follow-up study with revised coefficients, re-run the snippet above and update the JSON values (see [OG-IDN](https://github.com/EAPD-DRB/OG-IDN)).
 
 ### Aggregate transfers
 

--- a/docs/create_doc_figures.py
+++ b/docs/create_doc_figures.py
@@ -11,7 +11,6 @@ from ogcore.parameters import Specifications
 from ogcore import parameter_plots as pp
 from ogcore import demographics as demog
 
-
 CUR_DIR = os.path.dirname(os.path.realpath(__file__))
 UN_COUNTRY_CODE = "360"
 plot_path = os.path.join(CUR_DIR, "book", "content", "calibration", "images")

--- a/environment.yml
+++ b/environment.yml
@@ -34,7 +34,6 @@ dependencies:
 - pip
 - pip:
   - openpyxl>=3.1.2
-  - pandas-datareader
   - linecheck
   - ogcore
   - sphinx-exercise

--- a/examples/run_og_idn.py
+++ b/examples/run_og_idn.py
@@ -51,9 +51,11 @@ def main():
     ):
         defaults = json.load(file)
     p.update_specifications(defaults)
-    # Update parameters from calibrate.py Calibration class
+
     if is_connected():  # only update if connected to internet
-        c = Calibration(p)
+        c = Calibration(
+            p, update_from_api=False
+        )  # =True will update data from online sources
         updated_params = c.get_dict()
         p.update_specifications(updated_params)
 

--- a/examples/run_og_idn.py
+++ b/examples/run_og_idn.py
@@ -13,7 +13,6 @@ from ogcore import output_plots as op
 from ogcore.execute import runner
 from ogcore.utils import safe_read_pickle
 from ogidn.calibrate import Calibration
-from ogidn.utils import is_connected
 
 # Use a custom matplotlib style file for plots
 plt.style.use("ogcore.OGcorePlots")
@@ -52,12 +51,11 @@ def main():
         defaults = json.load(file)
     p.update_specifications(defaults)
 
-    if is_connected():  # only update if connected to internet
-        c = Calibration(
-            p, update_from_api=False
-        )  # =True will update data from online sources
-        updated_params = c.get_dict()
-        p.update_specifications(updated_params)
+    c = Calibration(
+        p, update_from_api=False
+    )  # =True will update data from online sources
+    updated_params = c.get_dict()
+    p.update_specifications(updated_params)
 
     # Run model
     start_time = time.time()

--- a/ogidn/calibrate.py
+++ b/ogidn/calibrate.py
@@ -1,9 +1,9 @@
 from ogidn import macro_params, income
 from ogidn import input_output as io
 import os
+import warnings
 import numpy as np
 import datetime
-from ogcore import demographics
 
 UN_COUNTRY_CODE = "360"
 
@@ -19,6 +19,8 @@ class Calibration:
         demographic_data_path=None,
         output_path=None,
         update_from_api=False,
+        imf_data_year=None,
+        imf_data_path=None,
     ):
         """
         Constructor for the Calibration class.
@@ -31,6 +33,8 @@ class Calibration:
             output_path (str): path to save output to
             update_from_api (bool): Set True if you want to pull updated
                 macro data from World Bank and UN APIs
+            imf_data_year (int | None): IMF target year override
+            imf_data_path (str | None): path to save IMF source data CSV
 
         Returns:
             None
@@ -41,73 +45,102 @@ class Calibration:
             if not os.path.exists(output_path):
                 os.makedirs(output_path)
 
+        # Initialize attributes. Only values refreshed successfully are
+        # returned by get_dict(), so p remains the baseline source.
+        self.macro_params = {}
+        self.demographic_params = {}
+        self.e = None
+        self.alpha_c = np.array([1.0]) if p.I == 1 else None
+        self.io_matrix = np.array([[1.0]]) if p.M == 1 else None
+
+        if not update_from_api:
+            return
+
         # Macro estimation
-        self.macro_params = macro_params.get_macro_params(
-            macro_data_start_year,
-            macro_data_end_year,
-            update_from_api=update_from_api,
-        )
+        try:
+            self.macro_params = macro_params.get_macro_params(
+                macro_data_start_year,
+                macro_data_end_year,
+                update_from_api=update_from_api,
+                imf_data_year=imf_data_year,
+                imf_data_path=imf_data_path,
+            )
+        except Exception as exc:
+            warnings.warn(f"Macro params update failed: {exc}", stacklevel=2)
 
         # io matrix and alpha_c
         if p.I > 1:  # no need if just one consumption good
-            alpha_c_dict = io.get_alpha_c()
-            # check that model dimensions are consistent with alpha_c
-            assert p.I == len(list(alpha_c_dict.keys()))
-            self.alpha_c = np.array(list(alpha_c_dict.values()))
-        else:
-            self.alpha_c = np.array([1.0])
+            try:
+                alpha_c_dict = io.get_alpha_c()
+                # check that model dimensions are consistent with alpha_c
+                assert p.I == len(list(alpha_c_dict.keys()))
+                self.alpha_c = np.array(list(alpha_c_dict.values()))
+            except Exception as exc:
+                warnings.warn(f"alpha_c update failed: {exc}", stacklevel=2)
         if p.M > 1:  # no need if just one production good
-            io_df = io.get_io_matrix()
-            # check that model dimensions are consistent with io_matrix
-            assert p.M == len(list(io_df.keys()))
-            self.io_matrix = io_df.values
-        else:
-            self.io_matrix = np.array([[1.0]])
+            try:
+                io_df = io.get_io_matrix()
+                # check that model dimensions are consistent with io_matrix
+                assert p.M == len(list(io_df.keys()))
+                self.io_matrix = io_df.values
+            except Exception as exc:
+                warnings.warn(f"io_matrix update failed: {exc}", stacklevel=2)
 
-        # demographics
-        self.demographic_params = demographics.get_pop_objs(
-            p.E,
-            p.S,
-            p.T,
-            0,
-            99,
-            country_id=UN_COUNTRY_CODE,
-            initial_data_year=p.start_year - 1,
-            final_data_year=p.start_year + 1,
-            GraphDiag=False,
-            download_path=demographic_data_path,
-        )
+        # demographics + earnings profiles
+        try:
+            from ogcore import demographics
 
-        # demographics for 80 period lives (needed for getting e below)
-        demog80 = demographics.get_pop_objs(
-            20,
-            80,
-            p.T,
-            0,
-            99,
-            country_id=UN_COUNTRY_CODE,
-            initial_data_year=p.start_year - 1,
-            final_data_year=p.start_year + 1,
-            GraphDiag=False,
-        )
+            self.demographic_params = demographics.get_pop_objs(
+                p.E,
+                p.S,
+                p.T,
+                0,
+                99,
+                country_id=UN_COUNTRY_CODE,
+                initial_data_year=p.start_year - 1,
+                final_data_year=p.start_year + 1,
+                GraphDiag=False,
+                download_path=demographic_data_path,
+            )
 
-        # earnings profiles
-        self.e = income.get_e_interp(
-            p.E,
-            p.S,
-            p.J,
-            p.lambdas,
-            demog80["omega_SS"],
-            plot_path=output_path,
-        )
+            # demographics for 80 period lives (needed for getting e below)
+            demog80 = demographics.get_pop_objs(
+                20,
+                80,
+                p.T,
+                0,
+                99,
+                country_id=UN_COUNTRY_CODE,
+                initial_data_year=p.start_year - 1,
+                final_data_year=p.start_year + 1,
+                GraphDiag=False,
+            )
+
+            self.e = income.get_e_interp(
+                p.E,
+                p.S,
+                p.J,
+                p.lambdas,
+                demog80["omega_SS"],
+                plot_path=output_path,
+            )
+        except Exception as exc:
+            warnings.warn(
+                f"Demographics/income update failed: {exc}", stacklevel=2
+            )
+            self.demographic_params = {}
+            self.e = None
 
     # method to return all newly calibrated parameters in a dictionary
     def get_dict(self):
-        dict = {}
-        dict.update(self.macro_params)
-        dict["e"] = self.e
-        dict["alpha_c"] = self.alpha_c
-        dict["io_matrix"] = self.io_matrix
-        dict.update(self.demographic_params)
+        d = {}
+        d.update(self.macro_params)
+        d.update(self.demographic_params)
+        if self.e is not None:
+            d["e"] = self.e
+        if self.alpha_c is not None:
+            d["alpha_c"] = self.alpha_c
+        if self.io_matrix is not None:
+            d["io_matrix"] = self.io_matrix
 
-        return dict
+        return d

--- a/ogidn/input_output.py
+++ b/ogidn/input_output.py
@@ -3,7 +3,6 @@ import numpy as np
 import os
 from ogidn.constants import CONS_DICT, PROD_DICT
 
-
 CUR_DIR = os.path.dirname(os.path.realpath(__file__))
 
 

--- a/ogidn/macro_params.py
+++ b/ogidn/macro_params.py
@@ -5,13 +5,199 @@ parameters for the OG-IDN model that rely on macro data for calibration.
 """
 
 # imports
-from pandas_datareader import wb
 import pandas as pd
 import numpy as np
 import requests
 import datetime
-import statsmodels.api as sm
 from io import StringIO
+from pathlib import Path
+
+
+def _fetch_wb_data(indicators, country_iso, start_year, end_year, source):
+    """
+    Fetch a set of World Bank indicators from the v2 API.
+
+    Args:
+        indicators (dict): mapping of label to indicator code
+        country_iso (str): ISO alpha-3 country code
+        start_year (int): first year to request
+        end_year (int): last year to request
+        source (int): World Bank source ID
+
+    Returns:
+        pandas.DataFrame: DataFrame indexed by year/quarter label
+    """
+    if source == 2:
+        date_range = f"{start_year}:{end_year}"
+    elif source == 20:
+        date_range = f"{start_year}Q1:{end_year}Q4"
+    else:
+        raise ValueError(f"Unsupported World Bank source: {source}")
+
+    data_frames = []
+    for label, indicator_code in indicators.items():
+        response = requests.get(
+            (
+                "https://api.worldbank.org/v2/country/"
+                f"{country_iso}/indicator/{indicator_code}"
+            ),
+            params={
+                "date": date_range,
+                "source": source,
+                "format": "json",
+                "per_page": 10000,
+            },
+            timeout=30,
+        )
+        response.raise_for_status()
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise ValueError(
+                f"Malformed World Bank response for {indicator_code}"
+            ) from exc
+
+        if (
+            not isinstance(payload, list)
+            or len(payload) < 2
+            or not isinstance(payload[1], list)
+        ):
+            raise ValueError(
+                f"Empty or malformed World Bank response for {indicator_code}"
+            )
+
+        series_data = {}
+        for row in payload[1]:
+            date = row.get("date")
+            if date is None:
+                continue
+            series_data[date] = row.get("value")
+
+        series = pd.Series(series_data, name=label)
+        series = pd.to_numeric(series, errors="coerce")
+        data_frames.append(series.to_frame())
+
+    data = pd.concat(data_frames, axis=1)
+    data.index.name = "year"
+    return data.sort_index(ascending=False)
+
+
+def _get_imf_macro_params(country_iso, target_year, data_path=None):
+    """
+    Fetch IMF GFS data and compute alpha_T and alpha_G.
+
+    Args:
+        country_iso (str): ISO alpha-3 country code
+        target_year (int): preferred calibration year
+        data_path (str | Path | None): optional path to save IMF CSV data
+
+    Returns:
+        dict: IMF-derived macro parameters
+    """
+    required_indicators = {"G2_T", "G24_T", "G27_T", "G271_T"}
+    data_path = Path(data_path) if data_path is not None else None
+    response = requests.get(
+        (
+            "https://api.imf.org/external/sdmx/3.0/data/dataflow/"
+            f"IMF.STA/GFS_SOO/12.0.0/"
+            f"{country_iso.upper()}.S1311.G2M.*.POGDP_PT.A"
+        ),
+        timeout=30,
+    )
+    response.raise_for_status()
+    try:
+        payload = response.json()
+        data = payload["data"]
+        structure = data["structures"][0]
+        data_set = data["dataSets"][0]
+        series_dimensions = structure["dimensions"]["series"]
+        observation_years = [
+            value.get("id", value.get("value"))
+            for value in structure["dimensions"]["observation"][0]["values"]
+        ]
+    except (ValueError, KeyError, IndexError, TypeError) as exc:
+        raise ValueError(
+            "Empty or malformed IMF response for GFS_SOO"
+        ) from exc
+
+    records = []
+    for series_key, series in data_set["series"].items():
+        dimension_indexes = [int(idx) for idx in series_key.split(":")]
+        labels = {
+            dim["id"]: dim["values"][idx]["id"]
+            for dim, idx in zip(series_dimensions, dimension_indexes)
+        }
+        indicator = labels.get("INDICATOR")
+        if indicator not in required_indicators:
+            continue
+        for observation_key, observation in series.get(
+            "observations", {}
+        ).items():
+            value = observation[0]
+            if value is None:
+                continue
+            records.append(
+                {
+                    "year": observation_years[int(observation_key)],
+                    "indicator": indicator,
+                    "value": float(value),
+                    "country_iso": country_iso.upper(),
+                    "sector": "S1311",
+                    "dataset": "IMF.STA:GFS_SOO(12.0.0)",
+                }
+            )
+
+    imf_data = pd.DataFrame(records)
+    if imf_data.empty:
+        raise ValueError("Empty or malformed IMF response for GFS_SOO")
+
+    if data_path is not None:
+        data_path.parent.mkdir(parents=True, exist_ok=True)
+        imf_data.sort_values(["indicator", "year"]).to_csv(
+            data_path, index=False
+        )
+        print(f"IMF data saved to {data_path}")
+
+    imf_data["year"] = pd.to_numeric(imf_data["year"], errors="coerce")
+    imf_data["value"] = pd.to_numeric(imf_data["value"], errors="coerce")
+    imf_data = imf_data.dropna(subset=["year", "value"])
+
+    available = (
+        imf_data.pivot_table(
+            index="year",
+            columns="indicator",
+            values="value",
+            aggfunc="first",
+        )
+        .sort_index()
+        .dropna(subset=sorted(required_indicators))
+    )
+    available = available.loc[available.index <= int(target_year)]
+
+    if available.empty:
+        raise ValueError(
+            f"No complete IMF data available for {country_iso.upper()} up to "
+            f"{target_year}"
+        )
+
+    selected_year = (
+        int(target_year)
+        if int(target_year) in available.index
+        else int(available.index.max())
+    )
+    if selected_year != int(target_year):
+        print(
+            f"Warning: No IMF data for {target_year}. Using last available "
+            f"year: {selected_year}"
+        )
+
+    values = available.loc[selected_year]
+    return {
+        "alpha_T": [(values["G27_T"] - values["G271_T"]) / 100],
+        "alpha_G": [
+            (values["G2_T"] - values["G24_T"] - values["G27_T"]) / 100
+        ],
+    }
 
 
 def get_macro_params(
@@ -19,6 +205,8 @@ def get_macro_params(
     data_end_date=datetime.datetime(2024, 12, 31),
     country_iso="IDN",
     update_from_api=False,
+    imf_data_year=None,
+    imf_data_path=None,
 ):
     """
     Compute values of parameters that are derived from macro data
@@ -29,6 +217,9 @@ def get_macro_params(
         country_iso (str): ISO code for country
         update_from_api (bool): Set True if you want to pull updated
             macro data from World Bank and UN APIs
+        imf_data_year (int | None): IMF target year override. Defaults to
+            data_end_date.year when None.
+        imf_data_path (str | Path | None): optional path to save IMF CSV data
 
     Returns:
         macro_parameters (dict): dictionary of parameter values
@@ -49,9 +240,6 @@ def get_macro_params(
     # Annual data
     wb_a_variable_dict = {
         "GDP per capita (constant 2015 US$)": "NY.GDP.PCAP.KD",
-        "Real GDP (constant 2015 US$)": "NY.GDP.MKTP.KD",
-        "Nominal GDP (current US$)": "NY.GDP.MKTP.CD",
-        "General government final consumption expenditure (current US$)": "NE.CON.GOVT.CD",
     }
     # Quarterly data
     wb_q_variable_dict = {
@@ -60,65 +248,91 @@ def get_macro_params(
         "Gross PSD Gen Gov - percentage of GDP": "DP.DOD.DECT.CR.GG.Z1",
     }
 
+    # Function to get the latest valid data if baseline_YYYYQ is missing or NaN
+    def get_valid_data(series, baseline_YYYYQ):
+        value = series.get(baseline_YYYYQ, None)
+
+        if pd.isna(value):
+            latest_non_nan = series.dropna().first_valid_index()
+
+            if latest_non_nan is not None:
+                print(
+                    f"Warning: No data for {baseline_YYYYQ}. Using last available quarter: {latest_non_nan}"
+                )
+                value = series.get(latest_non_nan, None)
+            else:
+                print(
+                    "Warning: No historical data available. Skipping update."
+                )
+                value = None
+
+        return value
+
     if update_from_api:
+        # Annual WB fetch (source=2) — drives g_y_annual only.
         try:
-            # pull series of interest from the WB using pandas_datareader
-            # Annual data
-            wb_data_a = wb.download(
-                indicator=wb_a_variable_dict.values(),
-                country=country_iso,
-                start=data_start_date,
-                end=data_end_date,
+            wb_data_a = _fetch_wb_data(
+                wb_a_variable_dict,
+                country_iso,
+                data_start_date.year,
+                data_end_date.year,
+                source=2,
             )
-            wb_data_a.rename(
-                columns=dict((y, x) for x, y in wb_a_variable_dict.items()),
-                inplace=True,
+
+            # Compute annual GDP growth safely
+            if "GDP per capita (constant 2015 US$)" in wb_data_a.columns:
+                g_y_series = wb_data_a[
+                    "GDP per capita (constant 2015 US$)"
+                ].pct_change(-1, fill_method=None)
+
+                # If all values are NaN, return None
+                g_y_annual = (
+                    g_y_series.mean() if not g_y_series.isna().all() else None
+                )
+                if g_y_annual is not None:
+                    macro_parameters["g_y_annual"] = g_y_annual
+            else:
+                print(
+                    "Warning: Missing GDP per capita data in World Bank data. Skipping update for g_y_annual."
+                )
+
+            if "g_y_annual" in macro_parameters:
+                print(
+                    "g_y_annual updated from World Bank API: "
+                    f"{macro_parameters['g_y_annual']}"
+                )
+            else:
+                print("Warning: Skipping update for g_y_annual.")
+        except Exception:
+            print("Failed to retrieve annual data from World Bank")
+            print("Will not update g_y_annual")
+
+        # Quarterly WB fetch (source=20) — drives initial_debt_ratio,
+        # initial_foreign_debt_ratio, zeta_D. Independent of annual fetch so
+        # one outage does not suppress both.
+        try:
+            wb_data_q = _fetch_wb_data(
+                wb_q_variable_dict,
+                country_iso,
+                data_start_date.year,
+                data_end_date.year,
+                source=20,
             )
-            # Quarterly data
-            wb_data_q = wb.download(
-                indicator=wb_q_variable_dict.values(),
-                country=country_iso,
-                start=data_start_date,
-                end=data_end_date,
-            )
-            wb_data_q.rename(
-                columns=dict((y, x) for x, y in wb_q_variable_dict.items()),
-                inplace=True,
-            )
-            # Remove the hierarchical index (country and year) of
-            # wb_data_q and create a single row index using year
-            wb_data_q = wb_data_q.reset_index()
-            wb_data_q = wb_data_q.set_index("year")
-
-            # Function to get the latest valid data if baseline_YYYYQ is missing or NaN
-            def get_valid_data(series, baseline_YYYYQ):
-                value = series.get(baseline_YYYYQ, None)
-
-                if pd.isna(value):
-                    latest_non_nan = series.dropna().last_valid_index()
-
-                    if latest_non_nan is not None:
-                        print(
-                            f"Warning: No data for {baseline_YYYYQ}. Using last available quarter: {latest_non_nan}"
-                        )
-                        value = series.get(latest_non_nan, None)
-                    else:
-                        print(
-                            "Warning: No historical data available. Skipping update."
-                        )
-                        value = None
-
-                return value
 
             # Compute macro parameters from WB data
-            macro_parameters["initial_debt_ratio"] = get_valid_data(
+            initial_debt_ratio = get_valid_data(
                 pd.Series(wb_data_q["Gross PSD Gen Gov - percentage of GDP"])
                 / 100,
                 baseline_YYYYQ,
             )
-            print(
-                f"initial_debt_ratio updated from World Bank API: {macro_parameters['initial_debt_ratio']}"
-            )
+            if initial_debt_ratio is not None:
+                macro_parameters["initial_debt_ratio"] = initial_debt_ratio
+                print(
+                    "initial_debt_ratio updated from World Bank API: "
+                    f"{macro_parameters['initial_debt_ratio']}"
+                )
+            else:
+                print("Warning: Skipping update for initial_debt_ratio.")
             # Compute initial_foreign_debt_ratio safely
             if (
                 "Gross PSD USD - external creditors" in wb_data_q.columns
@@ -135,52 +349,42 @@ def get_macro_params(
                     "Gross PSD USD - external creditors"
                 ] / total_debt.replace(0, np.nan)
 
-                macro_parameters["initial_foreign_debt_ratio"] = (
-                    get_valid_data(
-                        wb_data_q["foreign_debt_ratio"], baseline_YYYYQ
-                    )
+                initial_foreign_debt_ratio = get_valid_data(
+                    wb_data_q["foreign_debt_ratio"], baseline_YYYYQ
                 )
+                if initial_foreign_debt_ratio is not None:
+                    macro_parameters["initial_foreign_debt_ratio"] = (
+                        initial_foreign_debt_ratio
+                    )
             else:
                 print(
                     "Warning: Missing debt variables in World Bank data. Skipping update for initial_foreign_debt_ratio."
                 )
 
-            print(
-                f"initial_foreign_debt_ratio updated from World Bank API: {macro_parameters['initial_foreign_debt_ratio']}"
-            )
+            if "initial_foreign_debt_ratio" in macro_parameters:
+                print(
+                    "initial_foreign_debt_ratio updated from World Bank "
+                    "API: "
+                    f"{macro_parameters['initial_foreign_debt_ratio']}"
+                )
 
-            # Compute zeta_D safely
-            macro_parameters["zeta_D"] = [
-                macro_parameters["initial_foreign_debt_ratio"]
-            ]  # Since it's the same formula, we use the same calculated value
-
-            print(
-                f"zeta_D updated from World Bank API: {macro_parameters['zeta_D']}"
-            )
-
-            # Compute annual GDP growth safely
-            if "GDP per capita (constant 2015 US$)" in wb_data_a.columns:
-                g_y_series = wb_data_a[
-                    "GDP per capita (constant 2015 US$)"
-                ].pct_change(-1)
-
-                # If all values are NaN, return None
-                macro_parameters["g_y_annual"] = (
-                    g_y_series.mean() if not g_y_series.isna().all() else None
+                # Since it's the same formula, use the same calculated value
+                macro_parameters["zeta_D"] = [
+                    macro_parameters["initial_foreign_debt_ratio"]
+                ]
+                print(
+                    f"zeta_D updated from World Bank API: {macro_parameters['zeta_D']}"
                 )
             else:
                 print(
-                    "Warning: Missing GDP per capita data in World Bank data. Skipping update for g_y_annual."
+                    "Warning: Skipping update for "
+                    "initial_foreign_debt_ratio and zeta_D."
                 )
-
+        except Exception:
+            print("Failed to retrieve quarterly data from World Bank")
             print(
-                f"g_y_annual updated from World Bank API: {macro_parameters['g_y_annual']}"
-            )
-        except:
-            print("Failed to retrieve data from World Bank")
-            print("Will not update the following parameters:")
-            print(
-                "[initial_debt_ratio, initial_foreign_debt_ratio, zeta_D, g_y]"
+                "Will not update [initial_debt_ratio, "
+                "initial_foreign_debt_ratio, zeta_D]"
             )
     else:
         print("Not updating from World Bank API")
@@ -211,7 +415,7 @@ def get_macro_params(
             }
 
             print("Attempting to update gamma from ILOSTAT")
-            response = requests.get(target, headers=headers)
+            response = requests.get(target, headers=headers, timeout=30)
             if response.status_code != 200:
                 print(f"Error: Received status code {response.status_code}")
             else:
@@ -244,38 +448,27 @@ def get_macro_params(
     Calibrate parameters from IMF data
     """
     if update_from_api:
-        # alpha_T, non-social security benefits as a fraction of GDP
-        # source: https://data.imf.org/?sk=b052f0f0-c166-43b6-84fa-47cccae3e219&hide_uv=1
-        macro_parameters["alpha_T"] = [0.013 - 0.0]
-        # alpha_G, gov't consumption expenditures as a fraction of GDP
-        # source: https://data.imf.org/?sk=edb0cd70-0af3-40e1-a9c3-bdef83ee4d1e&hide_uv=1
-        macro_parameters["alpha_G"] = [0.165 - 0.02 - 0.013]
-
-    """"
-    Esimate the discount on sovereign yields relative to private debt
-    Follow the methodology in Li, Magud, Werner, Witte (2021)
-    available at:
-    https://www.imf.org/en/Publications/WP/Issues/2021/06/04/The-Long-Run-Impact-of-Sovereign-Yields-on-Corporate-Yields-in-Emerging-Markets-50224
-
-    Steps:
-    1) Generate modelled corporate yields (corp_yhat) for a range of
-    sovereign yields (sov_y)  using the estimated equation in col 2 of
-    table 8 (and figure 3). 2) Estimate the OLS using sovereign yields
-    as the dependent variable
-    """
-
-    # # estimate r_gov_shift and r_gov_scale
-    sov_y = np.arange(20, 120) / 10
-    corp_yhat = 8.199 - (2.975 * sov_y) + (0.478 * sov_y**2)
-    corp_yhat = sm.add_constant(corp_yhat)
-    mod = sm.OLS(
-        sov_y,
-        corp_yhat,
-    )
-    res = mod.fit()
-    # First term is the constant and needs to be divided by 100 to have
-    # the correct unit. Second term is the coefficient
-    macro_parameters["r_gov_shift"] = [-res.params[0] / 100]
-    macro_parameters["r_gov_scale"] = [res.params[1]]
+        try:
+            imf_year = (
+                data_end_date.year if imf_data_year is None else imf_data_year
+            )
+            macro_parameters.update(
+                _get_imf_macro_params(
+                    country_iso,
+                    imf_year,
+                    data_path=imf_data_path,
+                )
+            )
+            print(
+                f"alpha_T updated from IMF data: {macro_parameters['alpha_T']}"
+            )
+            print(
+                f"alpha_G updated from IMF data: {macro_parameters['alpha_G']}"
+            )
+        except Exception:
+            print("Failed to retrieve data from IMF")
+            print("Will not update alpha_T, alpha_G")
+    else:
+        print("Not updating alpha_T, alpha_G")
 
     return macro_parameters

--- a/ogidn/ogidn_default_parameters.json
+++ b/ogidn/ogidn_default_parameters.json
@@ -815,10 +815,10 @@
     "initial_debt_ratio": 0.387,
     "initial_Kg_ratio": 0.2,
     "r_gov_scale": [
-        0.2448476359365782
+        0.24485
     ],
     "r_gov_shift": [
-        -0.03376625043803517
+        -0.03377
     ],
     "cit_rate": [
         [
@@ -3144,9 +3144,6 @@
     "PIA_rate_bkt_3": 0.0,
     "PIA_maxpayment": 0.0,
     "PIA_minpayment": 0.0,
-    "replacement_rate_adjust": [
-        1.0
-    ],
     "budget_balance": false,
     "baseline_spending": false,
     "start_year": 2025,

--- a/ogidn/ogidn_multisector_default_parameters.json
+++ b/ogidn/ogidn_multisector_default_parameters.json
@@ -861,10 +861,10 @@
     "initial_debt_ratio": 0.387,
     "initial_Kg_ratio": 0.2,
     "r_gov_scale": [
-        0.2448476359365782
+        0.24485
     ],
     "r_gov_shift": [
-        -0.03376625043803517
+        -0.03377
     ],
     "cit_rate": [
         [

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setuptools.setup(
         "distributed>=2.30.1",
         "paramtools>=0.20.0",
         "requests",
-        "pandas-datareader",
         "xlwt",
         "openpyxl>=3.1.2",
         "statsmodels",

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -1,0 +1,145 @@
+"""
+Tests of calibrate.py module
+"""
+
+import warnings
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from ogidn.calibrate import Calibration
+
+
+def _make_mock_p(I=1, M=1):
+    p = MagicMock()
+    p.I = I
+    p.M = M
+    p.E = 20
+    p.S = 80
+    p.T = 160
+    p.J = 7
+    p.start_year = 2025
+    p.lambdas = np.array([0.25, 0.25, 0.0625, 0.0625, 0.0625, 0.0625, 0.25])
+    return p
+
+
+class TestOfflineMode:
+    def test_single_sector_returns_identity_values(self):
+        p = _make_mock_p(I=1, M=1)
+        c = Calibration(p, update_from_api=False)
+
+        d = c.get_dict()
+        assert "alpha_c" in d
+        assert "io_matrix" in d
+        np.testing.assert_array_equal(d["alpha_c"], np.array([1.0]))
+        np.testing.assert_array_equal(d["io_matrix"], np.array([[1.0]]))
+
+    def test_single_sector_no_demographics_or_macro(self):
+        p = _make_mock_p(I=1, M=1)
+        c = Calibration(p, update_from_api=False)
+
+        d = c.get_dict()
+        assert "e" not in d
+        assert "omega" not in d
+        assert "omega_SS" not in d
+        assert "g_n_ss" not in d
+        assert "g_y_annual" not in d
+        assert "initial_debt_ratio" not in d
+
+    def test_multi_sector_returns_empty_dict(self):
+        p = _make_mock_p(I=5, M=4)
+        c = Calibration(p, update_from_api=False)
+
+        assert c.alpha_c is None
+        assert c.io_matrix is None
+        assert c.get_dict() == {}
+
+    @patch("ogidn.calibrate.macro_params")
+    @patch("ogidn.calibrate.io")
+    def test_no_external_refresh_calls(self, mock_io, mock_macro):
+        p = _make_mock_p(I=5, M=4)
+        Calibration(p, update_from_api=False)
+
+        mock_macro.get_macro_params.assert_not_called()
+        mock_io.get_alpha_c.assert_not_called()
+        mock_io.get_io_matrix.assert_not_called()
+
+
+class TestOnlinePartialFailure:
+    @patch("ogidn.calibrate.macro_params")
+    def test_macro_failure_warns_and_omits(self, mock_macro):
+        mock_macro.get_macro_params.side_effect = RuntimeError("API down")
+
+        p = _make_mock_p(I=1, M=1)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with patch("ogcore.demographics.get_pop_objs") as mock_demog:
+                mock_demog.side_effect = RuntimeError("skip")
+                c = Calibration(p, update_from_api=True)
+
+        macro_warnings = [
+            warning
+            for warning in caught
+            if "Macro params" in str(warning.message)
+        ]
+        assert len(macro_warnings) == 1
+
+        d = c.get_dict()
+        assert "g_y_annual" not in d
+        assert "initial_debt_ratio" not in d
+
+    @patch("ogidn.calibrate.io")
+    @patch("ogidn.calibrate.macro_params")
+    def test_io_failure_warns_and_omits(self, mock_macro, mock_io):
+        mock_macro.get_macro_params.return_value = {"g_y_annual": 0.01}
+        mock_io.get_alpha_c.side_effect = RuntimeError("SAM unavailable")
+        mock_io.get_io_matrix.side_effect = RuntimeError("SAM unavailable")
+
+        p = _make_mock_p(I=5, M=4)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with patch("ogcore.demographics.get_pop_objs") as mock_demog:
+                mock_demog.side_effect = RuntimeError("skip")
+                c = Calibration(p, update_from_api=True)
+
+        alpha_warnings = [
+            warning for warning in caught if "alpha_c" in str(warning.message)
+        ]
+        io_warnings = [
+            warning
+            for warning in caught
+            if "io_matrix" in str(warning.message)
+        ]
+        assert len(alpha_warnings) == 1
+        assert len(io_warnings) == 1
+
+        d = c.get_dict()
+        assert "alpha_c" not in d
+        assert "io_matrix" not in d
+        assert d["g_y_annual"] == 0.01
+
+    @patch("ogidn.calibrate.macro_params")
+    def test_demographics_failure_warns_and_omits(self, mock_macro):
+        mock_macro.get_macro_params.return_value = {"g_y_annual": 0.01}
+
+        p = _make_mock_p(I=1, M=1)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with patch("ogcore.demographics.get_pop_objs") as mock_demog:
+                mock_demog.side_effect = RuntimeError("UN API down")
+                c = Calibration(p, update_from_api=True)
+
+        demo_warnings = [
+            warning
+            for warning in caught
+            if "Demographics/income" in str(warning.message)
+        ]
+        assert len(demo_warnings) == 1
+
+        d = c.get_dict()
+        assert "e" not in d
+        assert "omega" not in d
+        assert "omega_SS" not in d
+        assert d["g_y_annual"] == 0.01
+        assert "alpha_c" in d
+        assert "io_matrix" in d

--- a/tests/test_income.py
+++ b/tests/test_income.py
@@ -6,7 +6,6 @@ import pytest
 import numpy as np
 from ogidn import income
 
-
 # @pytest.mark.parametrize(
 #     "abil_wgts,expected_vals",
 #     [

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -6,7 +6,6 @@ import pandas as pd
 import pytest
 from ogidn import input_output as io
 
-
 sam_dict = {
     # "index": ["Beer", "Chocolate", "Car", "House"],
     "Ag": [30, 160, 0, 5],

--- a/tests/test_macro_params.py
+++ b/tests/test_macro_params.py
@@ -2,36 +2,459 @@
 Tests of macro_params.py module
 """
 
+import json
+from importlib.resources import files
+
+import pandas as pd
 import pytest
+import requests
+from ogcore.parameters import Specifications
+
 from ogidn import macro_params
 
 
-@pytest.mark.parametrize(
-    "update_from_api",
-    [True, False],
-    ids=["update_from_api=True", "update_from_api=False"],
-)
-def test_get_macro_params(update_from_api):
-    test_dict = macro_params.get_macro_params(update_from_api=update_from_api)
+class MockResponse:
+    """
+    Minimal mock response for requests.get().
+    """
+
+    def __init__(self, *, json_data=None, text="", status_code=200):
+        self._json_data = json_data
+        self.text = text
+        self.status_code = status_code
+
+    def json(self):
+        if isinstance(self._json_data, Exception):
+            raise self._json_data
+        return self._json_data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(
+                f"HTTP {self.status_code} returned from mocked request"
+            )
+
+
+def _wb_payload(observations):
+    return [
+        {
+            "page": 1,
+            "pages": 1,
+            "per_page": "10000",
+            "total": len(observations),
+        },
+        [
+            {
+                "date": date,
+                "value": value,
+                "indicator": {"id": "mock-indicator"},
+            }
+            for date, value in observations
+        ],
+    ]
+
+
+def _imf_payload(indicator_year_values, country="IDN"):
+    years = sorted(
+        {
+            int(year)
+            for observations in indicator_year_values.values()
+            for year in observations.keys()
+        }
+    )
+    indicators = list(indicator_year_values.keys())
+    return {
+        "meta": {},
+        "data": {
+            "dataSets": [
+                {
+                    "structure": 0,
+                    "action": "Replace",
+                    "series": {
+                        f"0:0:0:{indicator_idx}:0:0": {
+                            "attributes": [0, None, None],
+                            "observations": {
+                                str(years.index(int(year))): [str(value)]
+                                for year, value in observations.items()
+                            },
+                        }
+                        for indicator_idx, observations in enumerate(
+                            indicator_year_values.values()
+                        )
+                    },
+                }
+            ],
+            "structures": [
+                {
+                    "dimensions": {
+                        "series": [
+                            {"id": "COUNTRY", "values": [{"id": country}]},
+                            {"id": "SECTOR", "values": [{"id": "S1311"}]},
+                            {"id": "GFS_GRP", "values": [{"id": "G2M"}]},
+                            {
+                                "id": "INDICATOR",
+                                "values": [
+                                    {"id": indicator}
+                                    for indicator in indicators
+                                ],
+                            },
+                            {
+                                "id": "TYPE_OF_TRANSFORMATION",
+                                "values": [{"id": "POGDP_PT"}],
+                            },
+                            {
+                                "id": "FREQUENCY",
+                                "values": [{"id": "A"}],
+                            },
+                        ],
+                        "observation": [
+                            {
+                                "id": "TIME_PERIOD",
+                                "values": [
+                                    {"value": str(year)} for year in years
+                                ],
+                            }
+                        ],
+                    },
+                    "measures": {
+                        "observation": [{"id": "OBS_VALUE", "roles": []}]
+                    },
+                    "attributes": {
+                        "dimensionGroup": [],
+                        "series": [],
+                        "observation": [],
+                    },
+                    "annotations": [],
+                }
+            ],
+        },
+    }
+
+
+def _default_wb_payloads():
+    return {
+        "NY.GDP.PCAP.KD": _wb_payload(
+            [("2024", 100.0), ("2023", 80.0), ("2022", 64.0)]
+        ),
+        "DP.DOD.DECD.CR.PS.CD": _wb_payload(
+            [("2024Q4", 60.0), ("2024Q3", 58.0), ("2024Q2", 57.0)]
+        ),
+        "DP.DOD.DECX.CR.PS.CD": _wb_payload(
+            [("2024Q4", 40.0), ("2024Q3", 42.0), ("2024Q2", 43.0)]
+        ),
+        "DP.DOD.DECT.CR.GG.Z1": _wb_payload(
+            [("2024Q4", 50.0), ("2024Q3", 49.0), ("2024Q2", 48.0)]
+        ),
+    }
+
+
+def _mock_requests_get(
+    monkeypatch, *, wb_payloads=None, ilo_text=None, imf_json=None
+):
+    payloads = _default_wb_payloads() if wb_payloads is None else wb_payloads
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        if "worldbank.org" in url:
+            indicator_code = url.rstrip("/").split("/")[-1]
+            return MockResponse(json_data=payloads[indicator_code])
+        if "rplumber.ilo.org" in url:
+            return MockResponse(
+                text=ilo_text or "time,obs_value\n2024,40\n2023,39\n"
+            )
+        if "api.imf.org" in url:
+            return MockResponse(
+                json_data=imf_json
+                or _imf_payload(
+                    {
+                        "G2_T": {2023: 14.0, 2024: 14.5},
+                        "G24_T": {2023: 2.1, 2024: 2.2},
+                        "G27_T": {2023: 0.8, 2024: 0.9},
+                        "G271_T": {2023: 0.0, 2024: 0.1},
+                    }
+                )
+            )
+        raise AssertionError(f"Unexpected URL requested in test: {url}")
+
+    monkeypatch.setattr(macro_params.requests, "get", fake_get)
+
+
+def test_get_macro_params_update_from_api_false_returns_empty_dict():
+    test_dict = macro_params.get_macro_params(update_from_api=False)
 
     assert isinstance(test_dict, dict)
-    if update_from_api:
-        assert (
-            list(test_dict.keys()).sort()
-            == [
-                "r_gov_shift",
-                "r_gov_scale",
-                "alpha_T",
-                "alpha_G",
-                "initial_debt_ratio",
-                "g_y_annual",
-                "gamma",
-                "zeta_D",
-                "initial_foreign_debt_ratio",
-            ].sort()
-        )
-    else:
-        assert (
-            list(test_dict.keys()).sort()
-            == ["r_gov_shift", "r_gov_scale"].sort()
-        )
+    assert test_dict == {}
+
+
+def test_get_macro_params_update_from_api_true(monkeypatch):
+    _mock_requests_get(monkeypatch)
+
+    test_dict = macro_params.get_macro_params(update_from_api=True)
+
+    assert sorted(test_dict.keys()) == sorted(
+        [
+            "alpha_T",
+            "alpha_G",
+            "initial_debt_ratio",
+            "g_y_annual",
+            "gamma",
+            "zeta_D",
+            "initial_foreign_debt_ratio",
+        ]
+    )
+    assert test_dict["initial_debt_ratio"] == 0.5
+    assert test_dict["initial_foreign_debt_ratio"] == 0.4
+    assert test_dict["zeta_D"] == [0.4]
+    assert test_dict["g_y_annual"] == pytest.approx(0.25)
+    assert test_dict["gamma"] == [0.6]
+    assert test_dict["alpha_T"] == [pytest.approx(0.008)]
+    assert test_dict["alpha_G"] == [pytest.approx(0.114)]
+
+
+def test_world_bank_partial_data_does_not_collapse(monkeypatch):
+    _mock_requests_get(
+        monkeypatch,
+        wb_payloads={
+            "NY.GDP.PCAP.KD": _wb_payload(
+                [("2024", None), ("2023", None), ("2022", None)]
+            ),
+            "DP.DOD.DECD.CR.PS.CD": _wb_payload([]),
+            "DP.DOD.DECX.CR.PS.CD": _wb_payload([]),
+            "DP.DOD.DECT.CR.GG.Z1": _wb_payload(
+                [("2024Q4", None), ("2024Q3", 50.0), ("2024Q2", 48.0)]
+            ),
+        },
+    )
+    test_dict = macro_params.get_macro_params(update_from_api=True)
+
+    assert test_dict["initial_debt_ratio"] == 0.5
+    assert "initial_foreign_debt_ratio" not in test_dict
+    assert "zeta_D" not in test_dict
+    assert "g_y_annual" not in test_dict
+
+
+def test_wb_annual_fetch_failure_preserves_quarterly(monkeypatch):
+    """Annual WB source=2 down; quarterly source=20 still succeeds."""
+    payloads = _default_wb_payloads()
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        if "worldbank.org" in url:
+            if params and params.get("source") == 2:
+                raise requests.ConnectionError("annual source down")
+            indicator_code = url.rstrip("/").split("/")[-1]
+            return MockResponse(json_data=payloads[indicator_code])
+        if "rplumber.ilo.org" in url:
+            return MockResponse(text="time,obs_value\n2024,40\n2023,39\n")
+        if "api.imf.org" in url:
+            return MockResponse(
+                json_data=_imf_payload(
+                    {
+                        "G2_T": {2023: 14.0, 2024: 14.5},
+                        "G24_T": {2023: 2.1, 2024: 2.2},
+                        "G27_T": {2023: 0.8, 2024: 0.9},
+                        "G271_T": {2023: 0.0, 2024: 0.1},
+                    }
+                )
+            )
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    monkeypatch.setattr(macro_params.requests, "get", fake_get)
+
+    test_dict = macro_params.get_macro_params(update_from_api=True)
+
+    assert "g_y_annual" not in test_dict
+    assert test_dict["initial_debt_ratio"] == 0.5
+    assert test_dict["initial_foreign_debt_ratio"] == 0.4
+    assert test_dict["zeta_D"] == [0.4]
+
+
+def test_wb_quarterly_fetch_failure_preserves_annual(monkeypatch):
+    """Quarterly WB source=20 down; annual source=2 still succeeds."""
+    payloads = _default_wb_payloads()
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        if "worldbank.org" in url:
+            if params and params.get("source") == 20:
+                raise requests.ConnectionError("quarterly source down")
+            indicator_code = url.rstrip("/").split("/")[-1]
+            return MockResponse(json_data=payloads[indicator_code])
+        if "rplumber.ilo.org" in url:
+            return MockResponse(text="time,obs_value\n2024,40\n2023,39\n")
+        if "api.imf.org" in url:
+            return MockResponse(
+                json_data=_imf_payload(
+                    {
+                        "G2_T": {2023: 14.0, 2024: 14.5},
+                        "G24_T": {2023: 2.1, 2024: 2.2},
+                        "G27_T": {2023: 0.8, 2024: 0.9},
+                        "G271_T": {2023: 0.0, 2024: 0.1},
+                    }
+                )
+            )
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    monkeypatch.setattr(macro_params.requests, "get", fake_get)
+
+    test_dict = macro_params.get_macro_params(update_from_api=True)
+
+    assert test_dict["g_y_annual"] == pytest.approx(0.25)
+    assert "initial_debt_ratio" not in test_dict
+    assert "initial_foreign_debt_ratio" not in test_dict
+    assert "zeta_D" not in test_dict
+
+
+def test_get_macro_params_uses_last_valid_quarter(monkeypatch):
+    _mock_requests_get(
+        monkeypatch,
+        wb_payloads={
+            "NY.GDP.PCAP.KD": _wb_payload(
+                [("2024", 100.0), ("2023", 80.0), ("2022", 64.0)]
+            ),
+            "DP.DOD.DECD.CR.PS.CD": _wb_payload(
+                [("2024Q4", None), ("2024Q3", 60.0), ("2024Q2", None)]
+            ),
+            "DP.DOD.DECX.CR.PS.CD": _wb_payload(
+                [("2024Q4", None), ("2024Q3", 40.0), ("2024Q2", None)]
+            ),
+            "DP.DOD.DECT.CR.GG.Z1": _wb_payload(
+                [("2024Q4", None), ("2024Q3", 50.0), ("2024Q2", None)]
+            ),
+        },
+    )
+    test_dict = macro_params.get_macro_params(update_from_api=True)
+
+    assert test_dict["initial_debt_ratio"] == 0.5
+    assert test_dict["initial_foreign_debt_ratio"] == 0.4
+    assert test_dict["zeta_D"] == [0.4]
+
+
+def test_get_macro_params_uses_imf_year_override(monkeypatch):
+    _mock_requests_get(
+        monkeypatch,
+        imf_json=_imf_payload(
+            {
+                "G2_T": {2023: 14.0, 2024: 18.0},
+                "G24_T": {2023: 2.1, 2024: 3.0},
+                "G27_T": {2023: 0.8, 2024: 1.5},
+                "G271_T": {2023: 0.0, 2024: 0.2},
+            }
+        ),
+    )
+    test_dict = macro_params.get_macro_params(
+        update_from_api=True, imf_data_year=2023
+    )
+
+    assert test_dict["alpha_T"] == [pytest.approx(0.008)]
+    assert test_dict["alpha_G"] == [pytest.approx(0.111)]
+
+
+def test_get_imf_macro_params_overwrites_saved_file(monkeypatch, tmp_path):
+    _mock_requests_get(
+        monkeypatch,
+        imf_json=_imf_payload(
+            {
+                "G2_T": {2023: 14.0, 2024: 14.5},
+                "G24_T": {2023: 2.1, 2024: 2.2},
+                "G27_T": {2023: 0.8, 2024: 0.9},
+                "G271_T": {2023: 0.0, 2024: 0.1},
+            }
+        ),
+    )
+
+    data_file = tmp_path / "imf_gfs_soo_idn_s1311_g2m_pogdp_pt_a.csv"
+    result = macro_params._get_imf_macro_params(
+        "IDN", 2024, data_path=data_file
+    )
+
+    assert result["alpha_T"] == [pytest.approx(0.008)]
+    assert result["alpha_G"] == [pytest.approx(0.114)]
+    assert data_file.exists()
+
+    _mock_requests_get(
+        monkeypatch,
+        imf_json=_imf_payload(
+            {
+                "G2_T": {2023: 14.0, 2024: 15.0},
+                "G24_T": {2023: 2.1, 2024: 2.4},
+                "G27_T": {2023: 0.8, 2024: 1.0},
+                "G271_T": {2023: 0.0, 2024: 0.2},
+            }
+        ),
+    )
+
+    refreshed = macro_params._get_imf_macro_params(
+        "IDN", 2024, data_path=data_file
+    )
+
+    assert refreshed != result
+    saved_data = pd.read_csv(data_file)
+    saved_2024 = saved_data[saved_data["year"] == 2024].set_index("indicator")
+    assert saved_2024.loc["G27_T", "value"] == pytest.approx(1.0)
+    assert saved_2024.loc["G271_T", "value"] == pytest.approx(0.2)
+
+
+def test_get_imf_macro_params_falls_back_to_last_available_year(monkeypatch):
+    _mock_requests_get(
+        monkeypatch,
+        imf_json=_imf_payload(
+            {
+                "G2_T": {2023: 14.0},
+                "G24_T": {2023: 2.1},
+                "G27_T": {2023: 0.8},
+                "G271_T": {2023: 0.0},
+            }
+        ),
+    )
+
+    result = macro_params._get_imf_macro_params("IDN", 2024)
+
+    assert result["alpha_T"] == [pytest.approx(0.008)]
+    assert result["alpha_G"] == [pytest.approx(0.111)]
+
+
+def test_get_macro_params_ilo_request_uses_timeout(monkeypatch):
+    seen_timeouts = []
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        if "worldbank.org" in url:
+            indicator_code = url.rstrip("/").split("/")[-1]
+            return MockResponse(
+                json_data=_default_wb_payloads()[indicator_code]
+            )
+        if "rplumber.ilo.org" in url:
+            seen_timeouts.append(timeout)
+            return MockResponse(
+                text="time,obs_value\n2024,40\n2023,39\n", status_code=200
+            )
+        if "api.imf.org" in url:
+            return MockResponse(
+                json_data=_imf_payload(
+                    {
+                        "G2_T": {2023: 14.0, 2024: 14.5},
+                        "G24_T": {2023: 2.1, 2024: 2.2},
+                        "G27_T": {2023: 0.8, 2024: 0.9},
+                        "G271_T": {2023: 0.0, 2024: 0.1},
+                    }
+                )
+            )
+        raise AssertionError(f"Unexpected URL requested in test: {url}")
+
+    monkeypatch.setattr(macro_params.requests, "get", fake_get)
+
+    macro_params.get_macro_params(update_from_api=True)
+
+    assert seen_timeouts == [30]
+
+
+@pytest.mark.parametrize(
+    "defaults_file",
+    [
+        "ogidn_default_parameters.json",
+        "ogidn_multisector_default_parameters.json",
+    ],
+)
+def test_packaged_defaults_load_into_specifications(defaults_file):
+    p = Specifications()
+    with files("ogidn").joinpath(defaults_file).open("r") as file:
+        defaults = json.load(file)
+
+    p.update_specifications(defaults)


### PR DESCRIPTION
Ports the country-neutral structural improvements from OG-ZAF PRs #103, #106, and #111 into OG-IDN.

- Calibration runs offline. `_fetch_wb_data` and `_get_imf_macro_params` helpers isolate network calls; `Calibration(update_from_api=False)` works without internet.
- World Bank annual and quarterly fetches have independent `try/except` blocks so one failure no longer suppresses the other.
- `pandas-datareader` removed from `environment.yml` and `setup.py`; World Bank calls go through `requests`.
- Live r_gov OLS computation removed. The OLS fits a deterministic quadratic with no Indonesia-specific input, so the packaged JSON values (`r_gov_shift = -0.03377`, `r_gov_scale = 0.24485`) are exactly what it produced. Methodology is now in `docs/book/content/calibration/macro.md` with a runnable reproducer. `statsmodels` no longer required.
- `replacement_rate_adjust` JSON shape fix — aligns with OG-Core's current paramtools schema.
- `examples/run_og_idn.py` restores the `Calibration(p, update_from_api=False)` block mirroring `run_og_zaf.py`.
- `AGENTS.md` and `CLAUDE.md` added, ported from OG-ZAF with IDN substitutions.